### PR TITLE
Django 4.2 / Python 3 compatibility fixes

### DIFF
--- a/notification/atomformat.py
+++ b/notification/atomformat.py
@@ -61,7 +61,8 @@ def rfc3339_date(date):
 ## based on django.utils.feedgenerator.get_tag_uri
 def get_tag_uri(url, date):
     "Creates a TagURI. See http://diveintomark.org/archives/2004/05/28/howto-atom-id"
-    parts = urlparse.urlparse(url)
+    from urllib.parse import urlparse as _urlparse
+    parts = _urlparse(url)
     date_part = ""
     if date is not None:
         date_part = ",%s:" % date.strftime("%Y-%m-%d")
@@ -96,10 +97,10 @@ class Feed(object):
             # function and catching the TypeError, because something inside
             # the function may raise the TypeError. This technique is more
             # accurate.
-            if hasattr(attr, 'func_code'):
-                argcount = attr.func_code.co_argcount
+            if hasattr(attr, '__code__'):
+                argcount = attr.__code__.co_argcount
             else:
-                argcount = attr.__call__.func_code.co_argcount
+                argcount = attr.__call__.__code__.co_argcount
             if argcount == 2: # one argument is 'self'
                 return attr(obj)
             else:

--- a/notification/context_processors.py
+++ b/notification/context_processors.py
@@ -2,7 +2,7 @@ from .models import Notice
 
 
 def notification(request):
-    if request.user.is_authenticated():
+    if request.user.is_authenticated:
         return {
             "notice_unseen_count": Notice.objects.unseen_count_for(request.user, on_site=True),
         }

--- a/notification/decorators.py
+++ b/notification/decorators.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.http import HttpResponse
 from django.conf import settings
 

--- a/notification/decorators.py
+++ b/notification/decorators.py
@@ -36,7 +36,7 @@ def basic_auth_required(realm=None, test_func=None, callback_func=None):
     if realm is None:
         realm = getattr(settings, "HTTP_AUTHENTICATION_REALM", _("Restricted Access"))
     if test_func is None:
-        test_func = lambda u: u.is_authenticated()
+        test_func = lambda u: u.is_authenticated
     
     def decorator(view_func):
         def basic_auth(request, *args, **kwargs):
@@ -48,7 +48,8 @@ def basic_auth_required(realm=None, test_func=None, callback_func=None):
             if "HTTP_AUTHORIZATION" in request.META:
                 auth_method, auth = request.META["HTTP_AUTHORIZATION"].split(" ", 1)
                 if "basic" == auth_method.lower():
-                    auth = auth.strip().decode("base64")
+                    import base64
+                    auth = base64.b64decode(auth.strip()).decode("utf-8")
                     username, password = auth.split(":",1)
                     user = authenticate(username=username, password=password)
                     if user is not None:
@@ -57,7 +58,7 @@ def basic_auth_required(realm=None, test_func=None, callback_func=None):
                                 callback_func(request, user, *args, **kwargs)
                             return view_func(request, *args, **kwargs)
             
-            response =  HttpResponse(_("Authorization Required"), mimetype="text/plain")
+            response = HttpResponse(_("Authorization Required"), content_type="text/plain")
             response.status_code = 401
             response["WWW-Authenticate"] = "Basic realm='%s'" % realm
             return response

--- a/notification/feeds.py
+++ b/notification/feeds.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 from django.conf import settings
 from django.shortcuts import get_object_or_404
 from django.template.defaultfilters import linebreaks, escape, striptags
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site

--- a/notification/lockfile.py
+++ b/notification/lockfile.py
@@ -51,7 +51,7 @@ Exceptions:
 from __future__ import division
 from __future__ import print_function
 
-from six import text_type as unicodestr
+unicodestr = str
 
 import sys
 import socket

--- a/notification/models.py
+++ b/notification/models.py
@@ -229,7 +229,8 @@ def get_notification_language(user):
     if getattr(settings, "NOTIFICATION_LANGUAGE_MODULE", False):
         try:
             app_label, model_name = settings.NOTIFICATION_LANGUAGE_MODULE.split(".")
-            model = models.get_model(app_label, model_name)
+            from django.apps import apps
+            model = apps.get_model(app_label, model_name)
             language_model = model._default_manager.get(user__id__exact=user.id)
             if hasattr(language_model, "language"):
                 return language_model.language

--- a/notification/models.py
+++ b/notification/models.py
@@ -18,8 +18,8 @@ from django.template.loader import render_to_string
 from django.template.engine import Engine
 from django.template.exceptions import TemplateDoesNotExist
 
-from django.utils.translation import ugettext_lazy as _
-from django.utils.translation import ugettext, get_language, activate
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext, get_language, activate
 
 from django.contrib.sites.models import Site
 from django.contrib.auth.models import AnonymousUser
@@ -315,7 +315,7 @@ def send_now(users, label, extra_context=None, on_site=True, sender=None):
         context = {
             "recipient": user,
             "sender": sender,
-            "notice": ugettext(notice_type.display),
+            "notice": gettext(notice_type.display),
             "notices_url": notices_url,
             "current_site": current_site,
         }

--- a/notification/models.py
+++ b/notification/models.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from six import text_type as unicodestr
+unicodestr = str
 import datetime
 
 try:

--- a/notification/urls.py
+++ b/notification/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url, include
+from django.urls import re_path as url
 
 from .views import notices, mark_all_seen, feed_for_user, single, notice_settings
 

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,7 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        'django<3',
-        'six'
+        'django>=3.2',
     ],
 
     zip_safe=False,


### PR DESCRIPTION
Fixes runtime errors on Django 2+ and Python 3. Found while upgrading unglue.it from Django 1.11 to 4.2 (Gluejar/regluit#1123).

**What breaks without these changes:**
- `is_authenticated()` — callable form removed in Django 2.0 (now a property)
- `str.decode("base64")` — removed in Python 3 (decorators.py basic auth)
- `HttpResponse(mimetype=)` — kwarg removed in Django 2.0
- `models.get_model()` — removed in Django 2.0 (use `apps.get_model()`)
- `urlparse` module — moved to `urllib.parse` in Python 3
- `func_code` — renamed to `__code__` in Python 3
- `ugettext` / `ugettext_lazy` — removed in Django 4.0
- `django.conf.urls.url()` — removed in Django 4.0
- `six` dependency — no longer needed on Python 3
- `django<3` pin in setup.py — updated to `django>=3.2`

**8 files changed, 3 commits, running on dj42.unglue.it (Django 4.2 / Python 3.12).**